### PR TITLE
Integrate k8s plugin api

### DIFF
--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -18,7 +18,7 @@ export function QuayRepository(props: RepositoryProps) {
       props.organization,
       props.repository,
     );
-    if (tagsResponse.page == 1) {
+    if (tagsResponse.page === 1) {
       setTags(tagsResponse.tags);
     } else {
       setTags(currentTags => [...currentTags, ...tagsResponse.tags]);
@@ -31,21 +31,19 @@ export function QuayRepository(props: RepositoryProps) {
   }
 
   const data = tags?.map((tags: Tag) => {
-      return {
-          name: tags.name,
-          last_modified: formatDate(tags.last_modified),
-          size: formatSize(tags.size),
-          manifest_digest: tags.manifest_digest.substring(0, 19),
-          // expiration: tags.expiration,
-          // is_manifest_list: tags.is_manifest_list,
-          // reversion: tags.reversion,
-          // start_ts: tags.start_ts,
-          // end_ts: tags.end_ts,
-          // manifest_list: tags.manifest_list,
-          
-      };
+    return {
+      name: tags.name,
+      last_modified: formatDate(tags.last_modified),
+      size: formatSize(tags.size),
+      manifest_digest: tags.manifest_digest.substring(0, 19),
+      // expiration: tags.expiration,
+      // is_manifest_list: tags.is_manifest_list,
+      // reversion: tags.reversion,
+      // start_ts: tags.start_ts,
+      // end_ts: tags.end_ts,
+      // manifest_list: tags.manifest_list,
+    };
   });
-
 
   return (
     <div style={{ border: '1px solid #ddd' }}>

--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -30,18 +30,18 @@ export function QuayRepository(props: RepositoryProps) {
     return <Progress />;
   }
 
-  const data = tags?.map((tags: Tag) => {
+  const data = tags?.map((tag: Tag) => {
     return {
-      name: tags.name,
-      last_modified: formatDate(tags.last_modified),
-      size: formatSize(tags.size),
-      manifest_digest: tags.manifest_digest.substring(0, 19),
-      // expiration: tags.expiration,
-      // is_manifest_list: tags.is_manifest_list,
-      // reversion: tags.reversion,
-      // start_ts: tags.start_ts,
-      // end_ts: tags.end_ts,
-      // manifest_list: tags.manifest_list,
+      name: tag.name,
+      last_modified: formatDate(tag.last_modified),
+      size: formatSize(tag.size),
+      manifest_digest: tag.manifest_digest.substring(0, 19),
+      // expiration: tag.expiration,
+      // is_manifest_list: tag.is_manifest_list,
+      // reversion: tag.reversion,
+      // start_ts: tag.start_ts,
+      // end_ts: tag.end_ts,
+      // manifest_list: tag.manifest_list,
     };
   });
 

--- a/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -5,6 +5,7 @@ import { Link, Progress, Table } from '@backstage/core-components';
 import { columns, useStyles } from './tableHeading';
 import { Tag } from '../../types';
 import { quayApiRef } from '../../api';
+import { formatDate, formatSize } from '../utils';
 
 export function QuayRepository(props: RepositoryProps) {
   const quayClient = useApi(quayApiRef);
@@ -17,7 +18,7 @@ export function QuayRepository(props: RepositoryProps) {
       props.organization,
       props.repository,
     );
-    if (tagsResponse.page === 1) {
+    if (tagsResponse.page == 1) {
       setTags(tagsResponse.tags);
     } else {
       setTags(currentTags => [...currentTags, ...tagsResponse.tags]);
@@ -29,12 +30,29 @@ export function QuayRepository(props: RepositoryProps) {
     return <Progress />;
   }
 
+  const data = tags?.map((tags: Tag) => {
+      return {
+          name: tags.name,
+          last_modified: formatDate(tags.last_modified),
+          size: formatSize(tags.size),
+          manifest_digest: tags.manifest_digest.substring(0, 19),
+          // expiration: tags.expiration,
+          // is_manifest_list: tags.is_manifest_list,
+          // reversion: tags.reversion,
+          // start_ts: tags.start_ts,
+          // end_ts: tags.end_ts,
+          // manifest_list: tags.manifest_list,
+          
+      };
+  });
+
+
   return (
     <div style={{ border: '1px solid #ddd' }}>
       <Table
         title={title}
         options={{ paging: true, padding: 'dense' }}
-        data={tags}
+        data={data}
         columns={columns}
         emptyContent={
           <div className={classes.empty}>

--- a/plugins/quay/src/components/utils.tsx
+++ b/plugins/quay/src/components/utils.tsx
@@ -1,45 +1,43 @@
-import { VulnerabilitySeverity } from "../types";
+import { VulnerabilitySeverity } from '../types';
 
 export function getSeverityColor(severity: VulnerabilitySeverity) {
-    switch (severity) {
-      case VulnerabilitySeverity.Critical:
-        return '#7D1007';
-      case VulnerabilitySeverity.High:
-        return '#C9190B';
-      case VulnerabilitySeverity.Medium:
-        return '#EC7A08';
-      case VulnerabilitySeverity.Low:
-        return '#F0AB00';
-      case VulnerabilitySeverity.None:
-        return '#3E8635';
-      default:
-        return '#8A8D90';
-    }
+  switch (severity) {
+    case VulnerabilitySeverity.Critical:
+      return '#7D1007';
+    case VulnerabilitySeverity.High:
+      return '#C9190B';
+    case VulnerabilitySeverity.Medium:
+      return '#EC7A08';
+    case VulnerabilitySeverity.Low:
+      return '#F0AB00';
+    case VulnerabilitySeverity.None:
+      return '#3E8635';
+    default:
+      return '#8A8D90';
   }
-  
-  export function formatDate(date: string | number) {
-    if (date == -1) {
-      return 'N/A';
-    }
-  
-    const adjustedDate = typeof date === 'number' ? date * 1000 : date;
-    return new Date(adjustedDate).toLocaleString('en-US', {
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      timeStyle: 'short',
-      dateStyle: 'medium',
-    });
+}
+
+export function formatDate(date: string | number) {
+  if (date === -1) {
+    return 'N/A';
   }
-  
-  export function formatSize(sizeInBytes: number) {
-    if (!sizeInBytes) {
-      // null or undefined
-      return 'N/A';
-    }
-  
-    const i = Math.floor(Math.log(sizeInBytes) / Math.log(1024));
-    return (
-      Number((sizeInBytes / Math.pow(1024, i)).toFixed(2)) * 1 +
-      ' ' +
-      ['B', 'kB', 'MB', 'GB', 'TB'][i]
-    );
+
+  const adjustedDate = typeof date === 'number' ? date * 1000 : date;
+  return new Date(adjustedDate).toLocaleString('en-US', {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timeStyle: 'short',
+    dateStyle: 'medium',
+  });
+}
+
+export function formatSize(sizeInBytes: number) {
+  if (!sizeInBytes) {
+    // null or undefined
+    return 'N/A';
   }
+
+  const i = Math.floor(Math.log(sizeInBytes) / Math.log(1024));
+  return `${Number((sizeInBytes / Math.pow(1024, i)).toFixed(2)) * 1} ${
+    ['B', 'kB', 'MB', 'GB', 'TB'][i]
+  }`;
+}

--- a/plugins/quay/src/components/utils.tsx
+++ b/plugins/quay/src/components/utils.tsx
@@ -1,0 +1,45 @@
+import { VulnerabilitySeverity } from "../types";
+
+export function getSeverityColor(severity: VulnerabilitySeverity) {
+    switch (severity) {
+      case VulnerabilitySeverity.Critical:
+        return '#7D1007';
+      case VulnerabilitySeverity.High:
+        return '#C9190B';
+      case VulnerabilitySeverity.Medium:
+        return '#EC7A08';
+      case VulnerabilitySeverity.Low:
+        return '#F0AB00';
+      case VulnerabilitySeverity.None:
+        return '#3E8635';
+      default:
+        return '#8A8D90';
+    }
+  }
+  
+  export function formatDate(date: string | number) {
+    if (date == -1) {
+      return 'N/A';
+    }
+  
+    const adjustedDate = typeof date === 'number' ? date * 1000 : date;
+    return new Date(adjustedDate).toLocaleString('en-US', {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
+  }
+  
+  export function formatSize(sizeInBytes: number) {
+    if (!sizeInBytes) {
+      // null or undefined
+      return 'N/A';
+    }
+  
+    const i = Math.floor(Math.log(sizeInBytes) / Math.log(1024));
+    return (
+      Number((sizeInBytes / Math.pow(1024, i)).toFixed(2)) * 1 +
+      ' ' +
+      ['B', 'kB', 'MB', 'GB', 'TB'][i]
+    );
+  }

--- a/plugins/quay/src/components/utils.tsx
+++ b/plugins/quay/src/components/utils.tsx
@@ -24,7 +24,7 @@ export function formatDate(date: string | number) {
 
   const adjustedDate = typeof date === 'number' ? date * 1000 : date;
   return new Date(adjustedDate).toLocaleString('en-US', {
-    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timeZone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
     timeStyle: 'short',
     dateStyle: 'medium',
   });

--- a/plugins/topology/package.json
+++ b/plugins/topology/package.json
@@ -23,26 +23,27 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/catalog-model": "1.1.5",
+    "@backstage/catalog-model": "^1.1.5",
     "@backstage/core-components": "^0.12.3",
     "@backstage/core-plugin-api": "^1.3.0",
-    "@backstage/plugin-catalog-react": "1.2.4",
+    "@backstage/plugin-catalog-react": "^1.2.4",
+    "@backstage/plugin-kubernetes": "^0.7.7",
     "@backstage/theme": "^0.2.16",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
     "react-use": "^17.2.4",
     "@patternfly/patternfly": "4.217.1",
+    "@patternfly/react-charts": "6.94.7",
     "@patternfly/react-core": "4.267.6",
     "@patternfly/react-icons": "^4.93.3",
     "@patternfly/react-styles": "^4.92.3",
+    "@patternfly/react-tokens": "4.93.6",
     "@patternfly/react-topology": "^4.91.9",
-    "mobx": "^5.15.4",
-    "mobx-react": "^6.2.0",
-    "lodash": "^4.17.19",
     "classnames": "2.x",
-    "@patternfly/react-charts": "6.94.7",
-    "@patternfly/react-tokens": "4.93.6"
+    "lodash": "^4.17.19",
+    "mobx": "^5.15.4",
+    "mobx-react": "^6.2.0"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0"
@@ -56,8 +57,8 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "*",
-    "msw": "^0.49.0",
-    "cross-fetch": "^3.1.5"
+    "cross-fetch": "^3.1.5",
+    "msw": "^0.49.0"
   },
   "files": [
     "dist"

--- a/plugins/topology/src/components/Topology/TopologyWorkloadPackage.tsx
+++ b/plugins/topology/src/components/Topology/TopologyWorkloadPackage.tsx
@@ -18,7 +18,10 @@ import {
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import TopologyComponentFactory from './components/TopologyComponentFactory';
 import { updateTopologyDataModel } from './data-transforms/updateTopologyDataModel';
-import { mockResources, mockWatchedRes } from '../../data/mock-watched-res';
+import { mockWatchedRes } from '../../data/mock-watched-res';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { useKubernetesObjects } from '@backstage/plugin-kubernetes';
+import { getResources } from './utils/topology-utils';
 
 interface TopologyViewWorkloadComponentProps {
   useSidebar: boolean;
@@ -31,25 +34,29 @@ const TopologyViewWorkloadComponent: React.FunctionComponent<
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const controller = useVisualizationController();
   const [dataModel, setDataModel] = React.useState({});
-
+  const { entity } = useEntity();
+  const { kubernetesObjects, error } = useKubernetesObjects(entity);
   const layout = 'ColaNoForce';
 
   React.useEffect(() => {
     const fetchData = async () => {
-      const watchedRes = mockWatchedRes();
-      const dataModelRes = await updateTopologyDataModel(
-        mockResources,
-        watchedRes,
-      );
-      if (dataModelRes.model) {
-        setDataModel(dataModelRes.model);
+      if (kubernetesObjects && !error) {
+        const k8sResources = getResources(kubernetesObjects);
+        const watchedRes = mockWatchedRes();
+        const dataModelRes = await updateTopologyDataModel(
+          k8sResources,
+          watchedRes,
+        );
+        if (dataModelRes.model) {
+          setDataModel(dataModelRes.model);
+        }
       }
     };
 
     fetchData();
     // Don't update on option changes, its handled differently to not re-layout
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [kubernetesObjects, error]);
 
   React.useEffect(() => {
     if (dataModel) {

--- a/plugins/topology/src/components/Topology/hooks/useAllWatchResources.ts
+++ b/plugins/topology/src/components/Topology/hooks/useAllWatchResources.ts
@@ -1,12 +1,35 @@
-import { mockResources } from '../../../data/mock-watched-res';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { useKubernetesObjects } from '@backstage/plugin-kubernetes';
+import * as React from 'react';
 import { TopologyResourcesObject } from '../types/topology-types';
 import { WatchedResourceType, WatchK8sResults } from '../types/types';
+import { getResources } from '../utils/topology-utils';
 
 export const useAllWatchResources = (watchedResource: WatchedResourceType) => {
+  const { entity } = useEntity();
+  const { kubernetesObjects, error } = useKubernetesObjects(entity);
+  const [resources, setResources] = React.useState<
+    WatchK8sResults<TopologyResourcesObject>
+  >({});
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      if (kubernetesObjects && !error) {
+        const k8sResources: WatchK8sResults<TopologyResourcesObject> =
+          getResources(kubernetesObjects);
+        setResources(k8sResources);
+      }
+    };
+
+    fetchData();
+    // Don't update on option changes, its handled differently to not re-layout
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kubernetesObjects, error]);
+
   const watchResourceKind = Object.keys(watchedResource).reduce(
     (acc: WatchK8sResults<TopologyResourcesObject>, resKind) => {
-      if (mockResources[resKind]) {
-        acc[resKind] = mockResources[resKind];
+      if (resources[resKind]) {
+        acc[resKind] = resources[resKind];
       }
       return acc;
     },

--- a/plugins/topology/src/components/Topology/models.ts
+++ b/plugins/topology/src/components/Topology/models.ts
@@ -36,3 +36,23 @@ export const DeploymentModel: K8sModel = {
   id: 'deployment',
   labelPlural: 'Deployments',
 };
+
+export const ServiceModel: K8sModel = {
+  apiVersion: 'v1',
+  label: 'Service',
+  labelKey: 'public~Service',
+  plural: 'services',
+  abbr: 'S',
+  namespaced: true,
+  kind: 'Service',
+  id: 'service',
+  labelPlural: 'Services',
+  labelPluralKey: 'public~Services',
+};
+
+export const resourceModels = {
+  [DeploymentModel.plural]: DeploymentModel,
+  [PodModel.plural]: PodModel,
+  [ReplicaSetModel.plural]: ReplicaSetModel,
+  [ServiceModel.plural]: ServiceModel,
+};

--- a/plugins/topology/src/components/Topology/utils/pod-resource-utils.ts
+++ b/plugins/topology/src/components/Topology/utils/pod-resource-utils.ts
@@ -58,9 +58,9 @@ export const getActiveReplicaSets = (
   deployment: K8sResourceKind,
   resources: any,
 ) => {
-  const { replicaSets } = resources;
+  const { replicasets } = resources;
   const currentRevision = getDeploymentRevision(deployment);
-  const ownedRS = getOwnedResources(deployment, replicaSets?.data);
+  const ownedRS = getOwnedResources(deployment, replicasets?.data);
   return _.filter(
     ownedRS,
     rs =>
@@ -299,7 +299,7 @@ export const getResourcesToWatchForPods = (kind: string, namespace: string) => {
         kind: 'Pod',
         namespace,
       },
-      replicaSets: {
+      replicasets: {
         isList: true,
         kind: 'ReplicaSet',
         namespace,

--- a/plugins/topology/src/data/mock-watched-res.ts
+++ b/plugins/topology/src/data/mock-watched-res.ts
@@ -24,7 +24,7 @@ export const mockResources: WatchK8sResults<TopologyResourcesObject> = {
     loaded: true,
     loadError: '',
   },
-  replicaSets: {
+  replicasets: {
     loaded: true,
     loadError: '',
     data: [mockReplicasetData, mockReplicasetData2],


### PR DESCRIPTION
Fixes: https://github.com/janus-idp/backstage-plugins/issues/105

This PR integrates k8s plugin with topology plugin and uses its api to fetch the k8s resources from the cluster(s) and refactors data model/transform utils to generate correct data needed to be consumed by topology view.

Test Setup:
Install and configure kubernetes plugin by following these guides:
- https://backstage.io/docs/features/kubernetes/installation
- https://backstage.io/docs/features/kubernetes/configuration

Kubernetes plugin is properly configured and able to connect to the cluster via a `ServiceAccount`

Following `ClusterRole` must be granted to `ServiceAccount` accessing the cluster:
(k8s plugin by default tries to fetch the following resources and if access is not provided an error is shown)

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: backstage-read-only
rules:
  - apiGroups:
      - '*'
    resources:
      - pods
      - configmaps
      - services
      - deployments
      - replicasets
      - horizontalpodautoscalers
      - ingresses
      - statefulsets
      - limitranges
      - daemonsets
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - batch
    resources:
      - jobs
      - cronjobs
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - metrics.k8s.io
    resources:
      - pods
    verbs:
      - get
      - list
```

Create a service component entity - https://github.com/temp-demo-organisation/nationalparks-py/blob/master/catalog-info2.yaml

To get the resources from a k8s cluster do the following:
- K8s plugin identifies if the provided entity has k8s resources and if yes from which namespace it should get the resources based on the following annotations added to the entity's catalog-info.yaml
```
annotations: 
 backstage.io/kubernetes-id: nationalparks-py
 backstage.io/kubernetes-namespace: div
```

- For k8s plugin to get the desired entity's k8s resources the following label should be added to the resources `'backstage.io/kubernetes-id': nationalparks-py`

- A custom label selector can also be added which will then be used by Backstage to find the resources. The label selector takes precedence over the id annotation. 
   `backstage.io/kubernetes-label-selector': 'app=my-app,component=front-end`

In order to use k8s plugin to get the resources for Topology view, the above annotations/labels should be in place.

After following all the above steps kuberenets tab should show the resources info:
<img width="1792" alt="Screenshot 2023-02-10 at 10 49 49 PM" src="https://user-images.githubusercontent.com/20724543/218155504-e8a7ec9e-a9b3-4bfd-a5ee-1f42063da207.png">

Topology tab should show a topology view of the resources:
<img width="1792" alt="Screenshot 2023-02-10 at 10 49 57 PM" src="https://user-images.githubusercontent.com/20724543/218155636-38d28b99-b1ae-4fb1-9714-e67d02b04498.png">

 

